### PR TITLE
Exclude companion

### DIFF
--- a/flowtracks/analysis.py
+++ b/flowtracks/analysis.py
@@ -75,8 +75,13 @@ class FluidVelocitiesAnalyser(GeneralAnalyser):
         particles in the current frame. 1st array - fluid velocity. 2nd array
         - relative velocity.
         """
+        if frame.particles.has_property('companion'):
+            comp = np.nonzero(
+                frame.tracers.trajid()[:,None] == frame.particles.companion() )[0]
+        else:
+            comp = None
         self._interp.set_scene(frame.tracers.pos(), frame.particles.pos(),
-            frame.tracers.velocity())
+            frame.tracers.velocity(), comp)
         vel_interp = self._interp.interpolate()
         rel_vel = frame.particles.velocity() - vel_interp
         

--- a/flowtracks/analysis.py
+++ b/flowtracks/analysis.py
@@ -15,6 +15,16 @@ fluid velocity around a particle from its surrounding tracers.
 
 import numpy as np, tables
 
+def companion_indices(trids, companions):
+    """
+    Return an array giving for each companion its respective index in the 
+    trajectory ID array, or a negative number if not found.
+    """
+    comp = np.full_like(companions, -1)
+    idx = np.nonzero(trids[:,None] == companions)
+    comp[idx[1]] = idx[0]
+    return comp
+                
 class GeneralAnalyser(object):
     """
     This is the parent class for all analysers to be used by :func:`analysis`.
@@ -76,8 +86,8 @@ class FluidVelocitiesAnalyser(GeneralAnalyser):
         - relative velocity.
         """
         if frame.particles.has_property('companion'):
-            comp = np.nonzero(
-                frame.tracers.trajid()[:,None] == frame.particles.companion() )[0]
+            comp = companion_indices(
+                frame.tracers.trajid(), frame.particles.companion())
         else:
             comp = None
         self._interp.set_scene(frame.tracers.pos(), frame.particles.pos(),

--- a/flowtracks/interpolation.py
+++ b/flowtracks/interpolation.py
@@ -20,7 +20,8 @@ Interpolation routines.
 import numpy as np, warnings
 from ConfigParser import SafeConfigParser
 
-def select_neighbs(tracer_pos, interp_points, radius=None, num_neighbs=None):
+def select_neighbs(tracer_pos, interp_points, radius=None, num_neighbs=None,
+    companionship=None):
     """
     For each of m interpolation points, find its distance to all tracers. Use
     result to decide which tracers are the neighbours of each interpolation
@@ -34,6 +35,10 @@ def select_neighbs(tracer_pos, interp_points, radius=None, num_neighbs=None):
         num_neighbs.
     num_neighbs - number of closest neighbours to interpolate from. If None.
         uses all neighbours in a given radius. ``radius`` has precedence.
+    companionship - an optional array denoting for each interpolation point the
+        index of a tracer that should be excluded from it ("companion tracer"),
+        useful esp. for interpolating tracers unto themselves and for analysing
+        a simulated particle that started from a true tracer.
     
     Returns:
     dists - (m,n) array, the distance from each interpolation point to each
@@ -45,6 +50,8 @@ def select_neighbs(tracer_pos, interp_points, radius=None, num_neighbs=None):
         axis=2)
     
     dists[dists <= 0] = np.inf # Only for selection phase,later changed back.
+    if companionship is not None:
+        dists[np.arange(len(interp_points)), companionship] = np.inf
     
     if radius is None:
         if num_neighbs is None:
@@ -212,7 +219,7 @@ class Interpolant(object):
     def radius(self):
         return self._radius
     
-    def set_scene(self, tracer_pos, interp_points, data):
+    def set_scene(self, tracer_pos, interp_points, data, companionship=None):
         """
         Records scene data for future interpolation using the same scene.
         
@@ -224,10 +231,15 @@ class Interpolant(object):
         data - (n,d) array, the for the d-dimensional data for tracer n. For 
             example, in velocity interpolation this would be (n,3), each tracer
             having 3 components of velocity.
+        companionship - an optional array denoting for each interpolation point
+            the index of a tracer that should be excluded from it ("companion 
+            tracer"), useful esp. for analysing a simulated particle that 
+            started from a true tracer.
         """
         self.__tracers = tracer_pos
         self.__interp_pts = interp_points
         self.__data = data
+        self.__comp = companionship
         
         # empty the neighbours cache:
         self.__dists = None
@@ -252,11 +264,13 @@ class Interpolant(object):
         Populate the neighbours cache.
         """
         self.__dists, self.__active_neighbs = select_neighbs(
-            self.__tracers, self.__interp_pts, self._radius, self._neighbs)
+            self.__tracers, self.__interp_pts, self._radius, self._neighbs,
+            self.__comp)
             
         if self._method == 'rbf':
             self.__tracer_dists, _ = select_neighbs(
-                self.__tracers, self.__tracers, self._radius, self._neighbs)
+                self.__tracers, self.__tracers, self._radius, self._neighbs,
+                self.__comp)
                 
     def which_neighbours(self):
         """
@@ -324,7 +338,7 @@ class Interpolant(object):
         raise NotImplementedError("Interpolation method %s not supported" \
             % self._method)
     
-    def __call__(self, tracer_pos, interp_points, data):
+    def __call__(self, tracer_pos, interp_points, data, companionship=None):
         """
         Sets up the necessary parameters, and performs the interpolation.
         Does not change the scene set by set_scene if any, so may be used
@@ -338,6 +352,10 @@ class Interpolant(object):
         data - (n,d) array, the for the d-dimensional data for tracer n. For 
             example, in velocity interpolation this would be (n,3), each tracer
             having 3 components of velocity.
+        companionship - an optional array denoting for each interpolation point
+            the index of a tracer that should be excluded from it ("companion 
+            tracer"), useful esp. for analysing a simulated particle that 
+            started from a true tracer.
         
         Returns:
         vel_interp - an (m,3) array with the interpolated value at the position
@@ -352,14 +370,14 @@ class Interpolant(object):
             return np.zeros((interp_points.shape[0], ret_shape))
             
         dists, use_parts = select_neighbs(tracer_pos, interp_points, 
-            self._radius, self._neighbs)
+            self._radius, self._neighbs, companionship)
         
         if self._method == 'inv':
             return inv_dist_interp(dists, use_parts, data, self._par)
             
         elif self._method == 'rbf':
             tracer_dists = select_neighbs(tracer_pos, tracer_pos, 
-                self._radius, self._neighbs)[0]
+                self._radius, self._neighbs, companionship)[0]
             return rbf_interp(tracer_dists, dists, use_parts, data, self._par)
         
         elif self._method == 'corrfun':
@@ -399,7 +417,7 @@ class Interpolant(object):
         ret = (ret - local_interp[:,:,None]) / eps
         return ret
         
-    def neighb_dists(self, tracer_pos, interp_points):
+    def neighb_dists(self, tracer_pos, interp_points, companionship=None):
         """
         The distance from each interpolation point to each data point of those
         used for interpolation. Assumes, for now, a constant number of
@@ -410,13 +428,17 @@ class Interpolant(object):
             in [m]
         interp_points - (m,3) array, coordinates of points where interpolation 
             will be done.
+        companionship - an optional array denoting for each interpolation point
+            the index of a tracer that should be excluded from it ("companion 
+            tracer"), useful esp. for analysing a simulated particle that 
+            started from a true tracer.
         
         Returns:
         ndists - an (m,c) array, for c closest neighbours as defined during
             object construction.
         """
         dists, use_parts = select_neighbs(tracer_pos, interp_points, 
-            None, self._neighbs)
+            None, self._neighbs, companionship)
         
         nearest_tracers_count = min(tracer_pos.shape[0], self._neighbs)
         ndists = np.zeros((interp_points.shape[0], nearest_tracers_count))

--- a/flowtracks/interpolation.py
+++ b/flowtracks/interpolation.py
@@ -51,7 +51,8 @@ def select_neighbs(tracer_pos, interp_points, radius=None, num_neighbs=None,
     
     dists[dists <= 0] = np.inf # Only for selection phase,later changed back.
     if companionship is not None:
-        dists[np.arange(len(interp_points)), companionship] = np.inf
+        cif = companionship >= 0. # companion in frame
+        dists[np.nonzero(cif)[0], companionship[cif]] = np.inf
     
     if radius is None:
         if num_neighbs is None:

--- a/flowtracks/scene.py
+++ b/flowtracks/scene.py
@@ -78,8 +78,12 @@ class Scene(object):
         """
         self._file = tables.open_file(file_name)
         self._table = self._file.get_node('/particles')
-        traj_tags = self._file.get_node('/bounds')
-        self._trids = traj_tags.col('trajid')
+        try:
+            traj_tags = self._file.get_node('/bounds')
+            self._trids = traj_tags.col('trajid')
+        except:
+            self._trids = np.unique(self._table.col('trajid'))
+        
         self.set_frame_range(frame_range)
         
         # Cache data on user-visible columns:

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,67 @@
+"""
+Unit tests for a small part of the analysis code.
+"""
+
+import unittest, numpy as np
+from flowtracks.analysis import FluidVelocitiesAnalyser
+from flowtracks.trajectory import ParticleSnapshot, Frame
+from flowtracks.interpolation import Interpolant
+
+class TestFluidVels(unittest.TestCase):
+    def setUp(self):
+        tracer_pos = np.array([
+            [ 0.001, 0, 0],
+            [-0.001, 0, 0],
+            [0,  0.001, 0],
+            [0, -0.001, 0],
+            [0, 0,  0.001],
+            [0, 0, -0.001]
+        ])
+        tracer_vel = np.array([
+            [0., 1., 0.],
+            [0., 1., 0.],
+            [0., 2., 0.],
+            [0., 2., 0.],
+            [0., 1., 0.],
+            [0., 1., 0.],
+        ])
+        tracers = ParticleSnapshot(
+            tracer_pos, tracer_vel, trajid=np.arange(6), time=1.)
+        
+        self.pos = np.array([
+            [0,  0.0009, 0],
+            [0, -0.0009, 0],
+        ])
+        self.companions = np.r_[2, 3]
+        
+        self.frm = Frame()
+        self.frm.tracers = tracers
+        
+        self.analyser = FluidVelocitiesAnalyser(Interpolant('inv'))
+        
+    def test_vel_interp(self):
+        """Interpolating fluid velocity"""
+        particles =  ParticleSnapshot(
+            self.pos, np.zeros((2,3)), trajid=np.arange(2), time=1.)
+        self.frm.particles = particles 
+        
+        fvel, _ = self.analyser.analyse(self.frm, None)
+        correct_fvel = np.array([
+            [ 0., 1.81766935, 0.],
+            [ 0., 1.81766935, 0.]
+        ])
+        np.testing.assert_array_almost_equal(fvel, correct_fvel)
+        
+    def test_comp_interp(self):
+        """Interpolating fluid velocity, excluding companion."""
+        particles =  ParticleSnapshot(
+            self.pos, np.zeros((2,3)), trajid=np.arange(2), time=1.,
+            companion=self.companions)
+        self.frm.particles = particles
+        
+        fvel, _ = self.analyser.analyse(self.frm, None)
+        correct_fvel = np.array([
+            [ 0., 1., 0.],
+            [ 0., 1., 0.]
+        ])
+        np.testing.assert_array_almost_equal(fvel, correct_fvel)

--- a/tests/test_interp.py
+++ b/tests/test_interp.py
@@ -165,5 +165,28 @@ class TestJacobian(unittest.TestCase):
         # Non-diagonal elements:
         jac[:, [0,1,2], [0,1,2]] = 0
         self.failUnless(np.all(jac == 0))
+
+class TestCompanion(unittest.TestCase):
+    def test_select(self):
+        """Selecting neighbours excludes correct companions"""
+        tracer_pos = np.array([
+            [ 0.001, 0, 0],
+            [-0.001, 0, 0],
+            [0,  0.001, 0],
+            [0, -0.001, 0],
+            [0, 0,  0.001],
+            [0, 0, -0.001]
+        ])
+        pos = np.array([
+            [0,  0.0009, 0],
+            [0, -0.0009, 0],
+        ])
+        companions = np.r_[2, 3]
         
+        dist, use_parts = interpolation.select_neighbs(
+            tracer_pos, pos, num_neighbs=4, companionship=companions)
         
+        np.testing.assert_array_equal(use_parts, np.array([
+            [True, True, False, False, True, True],
+            [True, True, False, False, True, True]
+        ]))


### PR DESCRIPTION
This allows one to register a particle as "companion" - this particle will not be used in interpolation of fluid velocity (and the trajectory attribute will be available for other analysers that you write). Useful in simulating trajectories that start from an existing tracer data point - where you obviously have an unfair advantage in that initially your companion is very close to the simulation region.