### PR TITLE
PyTables migrated from CamelCase to _underscore

### DIFF
--- a/flowtracks/io.py
+++ b/flowtracks/io.py
@@ -807,9 +807,6 @@ def trajectories_table(fname, first=None, last=None):
     Returns:
     trajects - a list of Trajectory objects, each trimmed to the frame range.
     """
-    # see issue 
-    # outfile = tables.openFile(fname, mode='r')
-    # table = outfile.getNode('/particles')
     outfile = tables.open_file(fname, mode='r')
     table = outfile.get_node('/particles')
     

--- a/flowtracks/io.py
+++ b/flowtracks/io.py
@@ -807,8 +807,11 @@ def trajectories_table(fname, first=None, last=None):
     Returns:
     trajects - a list of Trajectory objects, each trimmed to the frame range.
     """
-    outfile = tables.openFile(fname, mode='r')
-    table = outfile.getNode('/particles')
+    # see issue 
+    # outfile = tables.openFile(fname, mode='r')
+    # table = outfile.getNode('/particles')
+    outfile = tables.open_file(fname, mode='r')
+    table = outfile.get_node('/particles')
     
     query_string = ('(trajid == trid)')
     if first is not None:


### PR DESCRIPTION
see https://github.com/OpenPTV/postptv/issues/30
outfile = tables.open_file(fname, mode='r')
table = outfile.get_node('/particles')