### PR TITLE
Run 2to3 + some manual fixes.

### DIFF
--- a/flowtracks/an_scene.py
+++ b/flowtracks/an_scene.py
@@ -44,7 +44,7 @@ class AnalysedScene(object):
         Return names that may be used to access data in any of the data sources
         available, whether analyses or inertial particles.
         """
-        return self._scene.get_particles().keys() + self._keys
+        return list(self._scene.get_particles().keys()) + self._keys
     
     def shapes(self):
         """
@@ -65,7 +65,7 @@ class AnalysedScene(object):
         if cond is not None:
             query_string = '&'.join([query_string, cond])
             
-        for t in xrange(*self._scene.get_range()):
+        for t in range(*self._scene.get_range()):
             yield t, self._table.read_where(query_string)
     
     def collect(self, keys, where=None):
@@ -87,12 +87,12 @@ class AnalysedScene(object):
         part_cond = None
         an_cond = None
         
-        pkeys = self._scene.get_particles().keys()
+        pkeys = set(self._scene.get_particles().keys())
         if where is not None:
             pc_add = []
             an_cond_add = []
             
-            for key, rng in where.iteritems():
+            for key, rng in where.items():
                 cond_string = gen_query_string(key, rng)                
                 if key in pkeys:
                     pc_add.append(cond_string)
@@ -157,7 +157,7 @@ class AnalysedScene(object):
         traj = self._scene.get_particles().trajectory_by_id(trid)
         
         # Trim last point of trajectory to match analysis:
-        kwds = dict((k, v[:-1]) for k, v in traj.as_dict().iteritems())
+        kwds = dict((k, v[:-1]) for k, v in traj.as_dict().items())
         kwds['trajid'] = trid
         
         # Fetch by foreign key from analysis:

--- a/flowtracks/format_docstrings.py
+++ b/flowtracks/format_docstrings.py
@@ -24,7 +24,7 @@ def parse_docstring(app, what, name, obj, options, lines):
     place = 0
     section = []
     bullet = False
-    for place in xrange(len(lines)):
+    for place in range(len(lines)):
         line = lines[place]
         
         # End section: flush into out_lines.

--- a/flowtracks/graphics.py
+++ b/flowtracks/graphics.py
@@ -116,7 +116,7 @@ def plot_vectors(vecs, indep, xlabel, fig=None, marker='-',
     u = np.zeros(vecs.shape[0])
     
     labels = ("X " + unit_str, "Y" + unit_str, "Z" + unit_str)
-    for subplt in xrange(3):
+    for subplt in range(3):
         pl.subplot(3,1,subplt + 1)
         pl.plot(indep, vecs[:,subplt], marker)
         pl.gca().get_xaxis().set_visible(False)

--- a/flowtracks/interpolation.py
+++ b/flowtracks/interpolation.py
@@ -19,7 +19,7 @@ Interpolation routines.
 
 import numpy as np, warnings
 from scipy.spatial import cKDTree
-from ConfigParser import SafeConfigParser
+from configparser import SafeConfigParser
 
 def select_neighbs(tracer_pos, interp_points, radius=None, num_neighbs=None,
     companionship=None):
@@ -127,7 +127,7 @@ def rbf_interp(tracer_dists, dists, use_parts, data, epsilon=1e-2):
     
     # Determine the set of coefficients for each particle:
     coeffs = np.zeros(dists.shape + (data.shape[-1],))
-    for pix in xrange(dists.shape[0]):
+    for pix in range(dists.shape[0]):
         neighbs = np.nonzero(use_parts[pix])[0]
         K = kernel[np.ix_(neighbs, neighbs)]
         
@@ -566,7 +566,7 @@ class GeneralInterpolant(object):
         nearest_tracers_count = min(tracer_pos.shape[0], self._neighbs)
         ndists = np.zeros((interp_points.shape[0], nearest_tracers_count))
         
-        for pt in xrange(interp_points.shape[0]):
+        for pt in range(interp_points.shape[0]):
             # allow assignment of less than the desired number of neighbours.
             ndists[pt] = dists[pt, use_parts[pt]]
         

--- a/flowtracks/io.py
+++ b/flowtracks/io.py
@@ -16,8 +16,8 @@ the various formats. They are documented here alongside the main entry points,
 so that users may access them directly if needed.
 """
 import os, os.path, re, itertools as itr
-from ConfigParser import SafeConfigParser
-from StringIO import StringIO
+from configparser import SafeConfigParser
+from io import StringIO
 
 import numpy as np
 from scipy import io
@@ -67,7 +67,7 @@ class FramesIterator(object):
     def __iter__(self):
         return self
     
-    def next(self):
+    def __next__(self):
         """
         Returns:
         frm_num - frame number as recorded in the file names.
@@ -98,7 +98,7 @@ class SingleFileIterator(object):
     def __iter__(self):
         return self
     
-    def next(self):
+    def __next__(self):
         """
         Returns:
         frm_num - frame number as recorded in the file names.
@@ -292,7 +292,7 @@ def iter_trajectories_ptvis(fname, first=None, last=None, frate=1., xuap=False,
         frm_iter = SingleFileIterator(fname, fmt)
     
     # In the first frame, every particle starts a trajectory.
-    frame_num, table = frm_iter.next()    
+    frame_num, table = next(frm_iter)    
     
     pos = table['pos']
     if not xuap: pos /=1000.
@@ -667,15 +667,15 @@ def save_trajectories(output_dir, trajects, per_traject_adds, **kwds):
     
     for traj in trajects:
         save_data = dict(('traj:' + k, v) \
-            for k, v in traj.as_dict().iteritems())
-        for k, v in per_traject_adds.iteritems():
+            for k, v in traj.as_dict().items())
+        for k, v in per_traject_adds.items():
             save_data[k] = v[traj.trajid()]
         
         np.savez(os.path.join(output_dir, 'traj_%d' % traj.trajid()),
             **save_data)
     
     # Save non-trajectory arrays:
-    for k, v in kwds.iteritems():
+    for k, v in kwds.items():
         np.save(os.path.join(output_dir, k), v)
     
 def save_particles_table(filename, trajects, trim=None):
@@ -706,14 +706,14 @@ def save_particles_table(filename, trajects, trim=None):
         if table is None:
             # Format of records in a trajectory array :
             fields = [('trajid', int, 1)] + [(field,) + desc \
-                for field, desc in traj.ext_schema().iteritems()]
+                for field, desc in traj.ext_schema().items()]
             dtype = np.dtype(fields)
             table = outfile.create_table('/', 'particles', dtype)
 
         arr = np.empty(len(traj) - trim_len, dtype=dtype)
         arr['trajid'] = traj.trajid()
         
-        for k, v in traj.as_dict().iteritems():
+        for k, v in traj.as_dict().items():
             if trim is None:
                 arr[k] = v
             else:
@@ -755,7 +755,7 @@ def save_frames_hdf(filename, frames):
         if table is None:
             # Format of records in a frame array:
             fields = [('time', int, 1)] + [(field,) + desc \
-                for field, desc in frame.ext_schema().iteritems()]
+                for field, desc in frame.ext_schema().items()]
             dtype = np.dtype(fields)
             table = outfile.create_table('/', 'particles', dtype)
         
@@ -765,7 +765,7 @@ def save_frames_hdf(filename, frames):
         arr = np.empty(len(frame), dtype=dtype)
         arr['time'] = frame.time()
         
-        for k, v in frame.as_dict().iteritems():
+        for k, v in frame.as_dict().items():
             arr[k] = v
         table.append(arr)
         
@@ -788,7 +788,7 @@ def save_frames_hdf(filename, frames):
     
     bounds_tab = outfile.create_table('/', 'bounds', 
         np.dtype([('trajid', int, 1), ('first', int, 1), ('last', int, 1)]))
-    for trid, bounds in ongoing_trajects.iteritems():
+    for trid, bounds in ongoing_trajects.items():
         bounds_tab.append([(trid, bounds[0], bounds[1])])
     bounds_tab.cols.trajid.create_index()
     

--- a/flowtracks/scene.py
+++ b/flowtracks/scene.py
@@ -16,7 +16,7 @@ Main design goals:
 """
 
 import itertools as it, tables, numpy as np
-from ConfigParser import SafeConfigParser
+from configparser import SafeConfigParser
 
 from .trajectory import Trajectory, ParticleSnapshot
 from .particle import Particle
@@ -231,7 +231,7 @@ class Scene(object):
         if cond is not None:
             query_string = '&'.join(query_string, cond)
             
-        for t in xrange(self._first, self._last):
+        for t in range(self._first, self._last):
             yield t, self._table.read_where(query_string)
     
     def frame_by_time(self, t):
@@ -314,7 +314,7 @@ class Scene(object):
         # Compose query to PyTables engine:
         conds = [self._frame_limit]
         if where is not None:
-            for key, rng in where.iteritems():
+            for key, rng in where.items():
                 conds.append(gen_query_string(key, rng))
         cond_string = ' & '.join(conds)
         

--- a/flowtracks/sequence.py
+++ b/flowtracks/sequence.py
@@ -4,7 +4,7 @@ import numpy as np
 from .io import trajectories, infer_format
 from .particle import Particle
 from .trajectory import take_snapshot, trajectories_in_frame, Frame
-from ConfigParser import SafeConfigParser
+from configparser import SafeConfigParser
 
 class Sequence(object):
     """
@@ -121,7 +121,7 @@ class Sequence(object):
         # Also caches the starts and ends of trajectories, so that accessing
         # only the ones relevant to a specific frame is easier.
         start_end = [(tr.time()[0], tr.time()[-1]) for tr in self.__ptraj]
-        self.__pstarts, self.__pends =  map(np.array, zip(*start_end))
+        self.__pstarts, self.__pends =  list(map(np.array, list(zip(*start_end))))
         
         return self.__ptraj
     
@@ -145,7 +145,7 @@ class Sequence(object):
         # Also caches the starts and ends of trajectories, so that accessing
         # only the ones relevant to a specific frame is easier.
         start_end = [(tr.time()[0], tr.time()[-1]) for tr in self.__ttraj]
-        self.__tstarts, self.__tends =  map(np.array, zip(*start_end))
+        self.__tstarts, self.__tends =  list(map(np.array, list(zip(*start_end))))
             
         return self.__ttraj
         
@@ -192,7 +192,7 @@ class Sequence(object):
         self._act_rng = (first, last)
         return self
     
-    def next(self):
+    def __next__(self):
         if self._frame == self._act_rng[1]:
             del self._act_rng
             raise StopIteration
@@ -271,11 +271,11 @@ class Sequence(object):
                 fargs = (self, frame, next_frame) + args
             frm_res = func(*fargs)
             
-            for k, v in frm_res.iteritems():
+            for k, v in frm_res.items():
                 res[k][frame_counters[k]] = v
                 frame_counters[k] += 1
         
-        for k in res.keys():
+        for k in list(res.keys()):
             res[k] = np.array(res[k])
         return res
     

--- a/flowtracks/smoothing.py
+++ b/flowtracks/smoothing.py
@@ -116,7 +116,7 @@ def savitzky_golay(trajs, fps, window_size, order):
             accel=newacc, vel_pp=nextvel, acc_pp = nextacc)
         
         # Copy unsmoothed properties from old trajectory:
-        for k, v in traj.as_dict().iteritems():
+        for k, v in traj.as_dict().items():
             if k not in smoothed_keys:
                 newtraj.create_property(k, v)
         

--- a/flowtracks/trajectory.py
+++ b/flowtracks/trajectory.py
@@ -39,7 +39,7 @@ class ParticleSet(object):
         base_vals.update(kwds)
         
         self._check_attr = [] # Attrs to look for when concatenating bundles
-        for n, v in base_vals.iteritems():
+        for n, v in base_vals.items():
             self.create_property(n, v)
     
     def create_property(self, propname, init_val):
@@ -74,9 +74,9 @@ class ParticleSet(object):
                 self.__dict__[attr][selector] = new_val
         
         self.__dict__[propname] = \
-            types.MethodType(getter, self, self.__class__)
+            types.MethodType(getter, self)
         self.__dict__['set_' + propname] = \
-            types.MethodType(setter, self, self.__class__)
+            types.MethodType(setter, self)
         
         if init_val is not None:
             self.__dict__['set_' + propname](init_val)
@@ -255,7 +255,7 @@ def trajectories_in_frame(trajects, frame_num,
     """
     if start_times is None or end_times is None:
         start_end = [(tr.time()[0], tr.time()[-1]) for tr in trajects]
-        start_times, end_times = map(np.array, zip(*start_end))
+        start_times, end_times = list(map(np.array, list(zip(*start_end))))
     
     end_frm = (frame_num + 1) if segs else frame_num
     cands = (frame_num >= start_times) & (end_frm <= end_times)
@@ -290,15 +290,15 @@ def take_snapshot(trajects, frame, schema):
     a :class:`ParticleSnapshot` object with all the particles in the given frame.
     """
     if len(trajects) == 0:
-        kwds = dict((k, np.empty((0,) + v)) for k, v in schema.iteritems())
+        kwds = dict((k, np.empty((0,) + v)) for k, v in schema.items())
         kwds['time'] = frame
         return ParticleSnapshot(trajid=np.empty(0), **kwds)
     
     kwds = dict((k, np.empty(
         (len(trajects),) + v, 
         dtype=trajects[0].__dict__['_' + k].dtype)) \
-        for k, v in schema.iteritems())
-    copy_keys = kwds.keys()
+        for k, v in schema.items())
+    copy_keys = list(kwds.keys())
     kwds['trajid'] = np.empty(len(trajects), dtype=np.int_)
     
     for trix, traj in enumerate(trajects):

--- a/tests/test_interp.py
+++ b/tests/test_interp.py
@@ -7,7 +7,7 @@ Created on Tue Feb  4 11:52:38 2014
 @author: yosef
 """
 
-import unittest, os, ConfigParser, numpy as np
+import unittest, os, configparser, numpy as np
 from flowtracks import interpolation
 
 class TestReadWrite(unittest.TestCase):
@@ -17,9 +17,9 @@ class TestReadWrite(unittest.TestCase):
         fname = os.path.join(fdir, 'testing_fodder/interpolant.cfg')
         interp = interpolation.read_interpolant(fname)
         
-        self.failUnlessEqual(interp.num_neighbs(), 4)
-        self.failUnlessEqual(interp._method, "inv")
-        self.failUnlessEqual(interp._par, 0.1)
+        self.assertEqual(interp.num_neighbs(), 4)
+        self.assertEqual(interp._method, "inv")
+        self.assertEqual(interp._par, 0.1)
     
     def test_write_sequence(self):
         """A test interpolant is faithfully reproduced from rewritten sequence"""
@@ -27,7 +27,7 @@ class TestReadWrite(unittest.TestCase):
         fname = os.path.join(fdir, 'testing_fodder/interpolant.cfg')
         interp = interpolation.read_interpolant(fname)
                 
-        cfg = ConfigParser.SafeConfigParser()
+        cfg = configparser.SafeConfigParser()
         interp.save_config(cfg)
         nfname = os.path.join(fdir, 'testing_fodder/analysis.cfg')
         with open(nfname, 'w') as fobj:
@@ -35,9 +35,9 @@ class TestReadWrite(unittest.TestCase):
         
         # Round-trip check:
         ninterp = interpolation.read_interpolant(fname)
-        self.failUnlessEqual(interp.num_neighbs(), ninterp.num_neighbs())
-        self.failUnlessEqual(interp._method, ninterp._method)
-        self.failUnlessEqual(interp._par, ninterp._par)
+        self.assertEqual(interp.num_neighbs(), ninterp.num_neighbs())
+        self.assertEqual(interp._method, ninterp._method)
+        self.assertEqual(interp._par, ninterp._par)
         
         os.remove(nfname)
 
@@ -67,7 +67,7 @@ class TestRepeatedInterp(unittest.TestCase):
         use_parts = self.interp.current_active_neighbs()
         correct_use_parts = np.array([[0, 3, 6, 9, 12, 15, 18, 21]])
         used_in_correct = use_parts[:,None,:] == correct_use_parts[:,:,None]
-        self.failUnlessEqual(
+        self.assertEqual(
             used_in_correct.any(axis=2).sum(axis=1), self.interp.num_neighbs())
     
     def test_interp_once(self):
@@ -93,7 +93,7 @@ class TestRepeatedInterp(unittest.TestCase):
         """Dropping particles from the interpolated scene"""
         self.interp.trim_points(np.r_[True])
         # Now the scene is empty, so we expect empty arrays
-        self.failUnlessEqual(self.interp.interpolate().shape[0], 0.)
+        self.assertEqual(self.interp.interpolate().shape[0], 0.)
 
 class MethodInterp(unittest.TestCase):
     def test_interp_rbf(self):
@@ -157,7 +157,7 @@ class TestJacobian(unittest.TestCase):
         np.testing.assert_array_equal(local, np.zeros((1,3)))
         
         jac = interp.eulerian_jacobian()
-        self.failUnless(np.all(jac[:, [0,1,2], [0,1,2]] != 0))
+        self.assertTrue(np.all(jac[:, [0,1,2], [0,1,2]] != 0))
         
         # Above test is symmetric. This would catch derivation direction 
         # bugs:
@@ -171,7 +171,7 @@ class TestJacobian(unittest.TestCase):
         
         # Non-diagonal elements:
         jac[:, [0,1,2], [0,1,2]] = 0
-        self.failUnless(np.all(jac == 0))
+        self.assertTrue(np.all(jac == 0))
 
 class TestCompanion(unittest.TestCase):
     def test_select(self):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -41,7 +41,7 @@ class TestPtvis(unittest.TestCase):
     
     def test_trajectories_ptvis(self):
         trjs = io.trajectories_ptvis(self.tmpl, self.first, self.last)
-        self.failUnlessEqual(len(trjs), len(self.correct))
+        self.assertEqual(len(trjs), len(self.correct))
         self.compare_trajectories(trjs, self.correct)
         
     def compare_trajectories(self, list1, list2):
@@ -53,16 +53,16 @@ class TestPtvis(unittest.TestCase):
             nptest.assert_array_almost_equal(trj.velocity(), correct.velocity())
             nptest.assert_array_almost_equal(trj.accel(), correct.accel())
             nptest.assert_array_almost_equal(trj.time(), correct.time())
-            self.failUnlessEqual(trj.trajid(), correct.trajid())
+            self.assertEqual(trj.trajid(), correct.trajid())
             
     def test_iter_trajectories_ptvis_xuap(self):
     	inName = './data/particles/xuap.%d'
     	trjs = io.trajectories_ptvis(inName, xuap = True, traj_min_len = 2)
-    	self.failUnlessEqual(len(trjs), 332)
+    	self.assertEqual(len(trjs), 332)
     	
     	# here it fails due to the same problem with traj_min_len
     	trjs = io.trajectories_ptvis(inName, xuap = True, traj_min_len = None)
-    	self.failUnlessEqual(len(trjs), 332)
+    	self.assertEqual(len(trjs), 332)
     	
     def test_trajectories_hdf(self):
         """HDF reading works"""

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -41,48 +41,48 @@ class TestScene(unittest.TestCase):
     def test_keys(self):
         """Reading known available keys with the needed exclusions"""
         correct_keys = ['velocity', 'pos', 'accel']
-        self.failUnlessEqual(self.scene.keys(), correct_keys)
+        self.assertEqual(list(self.scene.keys()), correct_keys)
         
     def test_iter_trajectories(self):
         """Iterating trajectories and getting correct Trajectory objects"""
         trjs = [tr for tr in self.scene.iter_trajectories()]
-        self.failUnlessEqual(len(trjs), len(self.correct))
+        self.assertEqual(len(trjs), len(self.correct))
         
         for trj, correct in zip(trjs, self.correct):
             nptest.assert_array_almost_equal(trj.pos(), correct.pos())
             nptest.assert_array_almost_equal(trj.velocity(), correct.velocity())
             nptest.assert_array_almost_equal(trj.accel(), correct.accel())
             nptest.assert_array_almost_equal(trj.time(), correct.time())
-            self.failUnlessEqual(trj.trajid(), correct.trajid())
+            self.assertEqual(trj.trajid(), correct.trajid())
     
     def test_iter_trajectories_subrange(self):
         """Iterating trajectories in part of the frame range."""
         self.scene.set_frame_range((10002, 10004))
         trjs = [tr for tr in self.scene.iter_trajectories()]
-        self.failUnlessEqual(len(trjs), len(self.correct))
+        self.assertEqual(len(trjs), len(self.correct))
         
         for trj, correct in zip(trjs, self.correct):
             nptest.assert_array_almost_equal(trj.pos(), correct.pos()[1:-1])
             nptest.assert_array_almost_equal(trj.velocity(), correct.velocity()[1:-1])
             nptest.assert_array_almost_equal(trj.accel(), correct.accel()[1:-1])
             nptest.assert_array_almost_equal(trj.time(), correct.time()[1:-1])
-            self.failUnlessEqual(trj.trajid(), correct.trajid())
+            self.assertEqual(trj.trajid(), correct.trajid())
      
     def test_iter_frames(self):
         """Iterating the HDF files by frames, and getting correct ParticleSnapshot objects"""
         schm = self.correct[0].schema()
         correct_frames = [take_snapshot(self.correct, frm, schm) \
-            for frm in xrange(10001, 10005)]
+            for frm in range(10001, 10005)]
         
         frames = [frm for frm in self.scene.iter_frames()]
-        self.failUnlessEqual(len(frames), len(correct_frames))
+        self.assertEqual(len(frames), len(correct_frames))
         
         for frm, correct in zip(frames, correct_frames):
             nptest.assert_array_almost_equal(frm.pos(), correct.pos())
             nptest.assert_array_almost_equal(frm.velocity(), correct.velocity())
             nptest.assert_array_almost_equal(frm.accel(), correct.accel())
             nptest.assert_array_almost_equal(frm.trajid(), correct.trajid())
-            self.failUnlessEqual(frm.time(), correct.time())
+            self.assertEqual(frm.time(), correct.time())
     
     def test_iter_frames_subrange(self):
         """Iterating frames subrange"""
@@ -90,22 +90,22 @@ class TestScene(unittest.TestCase):
         
         schm = self.correct[0].schema()
         correct_frames = [take_snapshot(self.correct, frm, schm) \
-            for frm in xrange(10002, 10004)]
+            for frm in range(10002, 10004)]
         
         frames = [frm for frm in self.scene.iter_frames()]
-        self.failUnlessEqual(len(frames), len(correct_frames))
+        self.assertEqual(len(frames), len(correct_frames))
         
         for frm, correct in zip(frames, correct_frames):
             nptest.assert_array_almost_equal(frm.pos(), correct.pos())
             nptest.assert_array_almost_equal(frm.velocity(), correct.velocity())
             nptest.assert_array_almost_equal(frm.accel(), correct.accel())
             nptest.assert_array_almost_equal(frm.trajid(), correct.trajid())
-            self.failUnlessEqual(frm.time(), correct.time())
+            self.assertEqual(frm.time(), correct.time())
     
     def test_collect(self):
         """Slicing the file by keys or expressions"""
         v = self.scene.collect(['velocity'])[0]
-        self.failUnlessEqual(v.shape, (12,3))
+        self.assertEqual(v.shape, (12,3))
         
         v = v.reshape(3,4,3)
         nptest.assert_array_almost_equal(v[0,:,0], v[1,:,1])
@@ -113,7 +113,7 @@ class TestScene(unittest.TestCase):
 
 class TestUtils(unittest.TestCase):
     def test_query_string(self):
-        self.failUnlessEqual(gen_query_string('example', (-1, 1, False)),
+        self.assertEqual(gen_query_string('example', (-1, 1, False)),
             "((example >= -1) & (example < 1))")
-        self.failUnlessEqual(gen_query_string('example', (-1, 1, True)),
+        self.assertEqual(gen_query_string('example', (-1, 1, True)),
             '((example < -1) | (example >= 1))')

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -7,7 +7,7 @@ Created on Tue Feb  4 11:52:38 2014
 @author: yosef
 """
 
-import unittest, os, ConfigParser
+import unittest, os, configparser
 from flowtracks import sequence
 
 class TestReadWrite(unittest.TestCase):
@@ -17,9 +17,9 @@ class TestReadWrite(unittest.TestCase):
         fname = os.path.join(fdir, 'testing_fodder/sequence.cfg')
         seq = sequence.read_sequence(fname)
         
-        self.failUnlessEqual(seq.frate, 500)
-        self.failUnlessEqual(seq.range(), (10000, 10201))
-        self.failUnlessEqual(seq.part_fname(), '../data/particles/xuap.%d')
+        self.assertEqual(seq.frate, 500)
+        self.assertEqual(seq.range(), (10000, 10201))
+        self.assertEqual(seq.part_fname(), '../data/particles/xuap.%d')
     
     def test_write_sequence(self):
         """A test sequence is faithfully reproduced from rewritten sequence"""
@@ -27,7 +27,7 @@ class TestReadWrite(unittest.TestCase):
         fname = os.path.join(fdir, 'testing_fodder/sequence.cfg')
         seq = sequence.read_sequence(fname)
         
-        cfg = ConfigParser.SafeConfigParser()
+        cfg = configparser.SafeConfigParser()
         seq.save_config(cfg)
         nfname = os.path.join(fdir, 'testing_fodder/analysis.cfg')
         with open(nfname, 'w') as fobj:
@@ -35,8 +35,8 @@ class TestReadWrite(unittest.TestCase):
         
         # Round-trip check:
         nseq = sequence.read_sequence(nfname)
-        self.failUnlessEqual(seq.frate, nseq.frate)
-        self.failUnlessEqual(seq.range(), nseq.range())
-        self.failUnlessEqual(seq.part_fname(), nseq.part_fname())
+        self.assertEqual(seq.frate, nseq.frate)
+        self.assertEqual(seq.range(), nseq.range())
+        self.assertEqual(seq.part_fname(), nseq.part_fname())
         
         os.remove(nfname)


### PR DESCRIPTION
I ran the 2to3 script and made some manual fixes.
The changes are in-place, which means we abandon py2. I'm totally fine with it, but if it's not what you want, we'll probably need these changes, but in a set of .py3 files alongside the original py files (it's a maintenance burden).

the test suite passes with nosetests3, except for one test that didn't pass for py2 either. I thought I fixed it in the past but apparently I didn't. I don't remember now what it was, so maybe fixing it should be left as an exercise for somebody else.